### PR TITLE
release: v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-04-04
+
+### Fixed
+- **Folder watcher resource limits** — Cap active file watchers at 10 to prevent file descriptor exhaustion; evicts the oldest watcher when the limit is exceeded
+- **Duplicate watcher prevention** — `add_folder` is now idempotent; adding an already-watched path is a no-op
+- **Watcher cleanup on project switch** — Previous project's file watcher is removed before starting a new one, preventing watcher accumulation
+
+### Added
+- Supervisor test coverage for watcher lifecycle, idempotency, and cap enforcement
+
 ## [0.10.0] - 2026-04-02
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ClaudePlans.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
 
   def project do
     [


### PR DESCRIPTION
## Summary
- Bump version to 0.10.1
- Update CHANGELOG.md

### What's new in v0.10.1

#### Fixed
- **Folder watcher resource limits** — Cap active file watchers at 10 to prevent file descriptor exhaustion; evicts the oldest watcher when the limit is exceeded
- **Duplicate watcher prevention** — `add_folder` is now idempotent; adding an already-watched path is a no-op
- **Watcher cleanup on project switch** — Previous project's file watcher is removed before starting a new one, preventing watcher accumulation

#### Added
- Supervisor test coverage for watcher lifecycle, idempotency, and cap enforcement

## Post-merge
```
git checkout main && git pull
git tag v0.10.1
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)