### PR TITLE
fix: clear activity unread dot when selecting plan event

### DIFF
--- a/lib/claude_plans/web/browser_live.ex
+++ b/lib/claude_plans/web/browser_live.ex
@@ -501,10 +501,19 @@ defmodule ClaudePlans.Web.BrowserLive do
       event ->
         diff_html = compute_activity_diff(event)
 
+        unchecked =
+          if event.category == :plan do
+            VersionStore.mark_checked(event.filename)
+            VersionStore.unchecked_files()
+          else
+            socket.assigns.unchecked_plan_files
+          end
+
         {:noreply,
          assign(socket,
            selected_activity_index: idx,
-           activity_diff_html: diff_html
+           activity_diff_html: diff_html,
+           unchecked_plan_files: unchecked
          )}
     end
   end


### PR DESCRIPTION
## Summary
- Clicking a plan activity event previously showed the preview but didn't call `mark_checked`, so the unread dot persisted until the user navigated to the plan via the goto button.
- Call `mark_checked` when the event is selected so the unread indicator clears in the expected spot.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` — 79 tests passing
- [ ] Manual: trigger a plan change → unread dot appears on the activity event → click event preview → dot clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)