### PR TITLE
fix(ci): pin OTP to 27.3.4.9 for Burrito-compatible ERTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
       - name: Install Erlang & Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: '27'
+          # Pinned to a patch that Burrito's ERTS CDN has prebuilt.
+          # `'27'` resolves to the newest 27.x, which may not yet exist on
+          # beam-machine-universal.b-cdn.net — bump only after confirming
+          # the target patch returns 200 there.
+          otp-version: '27.3.4.9'
           elixir-version: '1.17'
 
       - name: Install Zig


### PR DESCRIPTION
## Summary
- Release workflow used `otp-version: '27'` which resolves to the newest 27.x (currently 27.3.4.11). Burrito fetches that exact patch from its ERTS CDN and fails with 404 when the CDN hasn't prebuilt it yet (observed on v0.10.2 release build).
- Pin to `27.3.4.9`, the patch v0.10.1 built against successfully. Added a comment documenting the coupling so future bumps verify CDN availability first.

## Verified
- `curl -I` against `beam-machine-universal.b-cdn.net`:
  - `OTP-27.3.4.11` → 404 (broke the release)
  - `OTP-27.3.4.10` → 200
  - `OTP-27.3.4.9` → 200 (chosen — known-good from v0.10.1)

## Test plan
- [ ] Merge → re-tag v0.10.2 → release workflow reaches the `Create Release` step successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)