### PR TITLE
fix: clear annotation panel when switching files

### DIFF
--- a/lib/claude_plans/web/live/folders_viewer_component.ex
+++ b/lib/claude_plans/web/live/folders_viewer_component.ex
@@ -302,7 +302,7 @@ defmodule ClaudePlans.Web.FoldersViewerComponent do
           |> Map.put(:versions, VersionStore.list_versions(version_key))
           |> Map.put(:has_file_annotations, Annotations.present?(content))
 
-        assign(socket, viewer: viewer)
+        assign_viewer(socket, viewer)
 
       {:error, _} ->
         socket
@@ -314,7 +314,13 @@ defmodule ClaudePlans.Web.FoldersViewerComponent do
   end
 
   defp update_viewer(socket, fun) do
-    viewer = fun.(socket.assigns.viewer)
+    assign_viewer(socket, fun.(socket.assigns.viewer))
+  end
+
+  # Switching files resets the in-component viewer but the parent mirrors
+  # annotation state in its own assign — without this notify, the panel keeps
+  # rendering annotations from the previously selected file.
+  defp assign_viewer(socket, viewer) do
     notify_annotation_state(socket.assigns.viewer, viewer)
     assign(socket, viewer: viewer)
   end

--- a/lib/claude_plans/web/live/projects_viewer_component.ex
+++ b/lib/claude_plans/web/live/projects_viewer_component.ex
@@ -291,7 +291,7 @@ defmodule ClaudePlans.Web.ProjectsViewerComponent do
           |> Map.put(:versions, VersionStore.list_versions(version_key))
           |> Map.put(:has_file_annotations, Annotations.present?(content))
 
-        assign(socket, viewer: viewer)
+        assign_viewer(socket, viewer)
 
       {:error, _} ->
         socket
@@ -303,7 +303,13 @@ defmodule ClaudePlans.Web.ProjectsViewerComponent do
   end
 
   defp update_viewer(socket, fun) do
-    viewer = fun.(socket.assigns.viewer)
+    assign_viewer(socket, fun.(socket.assigns.viewer))
+  end
+
+  # Switching files resets the in-component viewer but the parent mirrors
+  # annotation state in its own assign — without this notify, the panel keeps
+  # rendering annotations from the previously selected file.
+  defp assign_viewer(socket, viewer) do
     notify_annotation_state(socket.assigns.viewer, viewer)
     assign(socket, viewer: viewer)
   end


### PR DESCRIPTION
## Summary
- **Bug:** On Projects/Folders tabs, after creating annotations on file A then selecting file B, the file content updated but the annotation panel kept rendering A's annotations and couldn't be cleared.
- **Root cause:** The viewer components mirror annotation state up to `BrowserLive` via a `notify_annotation_state` message, but only `update_viewer/2` (event path) called it — `load_file/2` (file-select path) bypassed it. The component's internal viewer reset cleanly; the parent's mirrored assign went stale.
- **Fix:** Extracted `assign_viewer/2` helper that always calls `notify_annotation_state` and routed both `load_file/2` and `update_viewer/2` through it, in `FoldersViewerComponent` and `ProjectsViewerComponent`.

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix test` — 79/0 passing
- [ ] Manual repro: select file A on Projects tab → annotate → select file B → annotation panel clears
- [ ] Same on Folders tab
- [ ] Plans tab unchanged (already worked correctly via `reset_annotation_assigns`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)