### PR TITLE
feat(browse): local fuzzy fallback + skip heavy dirs in indexer

### DIFF
--- a/lib/claude_plans/dir_index.ex
+++ b/lib/claude_plans/dir_index.ex
@@ -10,6 +10,11 @@ defmodule ClaudePlans.DirIndex do
   @max_entries 10_000
   @rescan_interval_ms 300_000
 
+  # Directories we never descend into — they're huge, rarely contain the user's
+  # own work, and would exhaust `@max_entries` before reaching real projects.
+  # Build artifacts, package caches, VCS internals.
+  @skip_dirs ~w(deps node_modules _build target dist build .venv venv __pycache__ Pods vendor .next .nuxt .turbo)
+
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -40,6 +45,18 @@ defmodule ClaudePlans.DirIndex do
   @spec add_path(String.t()) :: :ok
   def add_path(full_path) do
     GenServer.cast(__MODULE__, {:add_path, full_path})
+  end
+
+  @doc """
+  Pure subsequence-match helper — same scoring as `search/2`, but run against
+  a caller-supplied string. Lets callers score arbitrary paths (e.g. the
+  directory they're currently browsing) using the same semantics as the index.
+  """
+  @spec match_string(String.t(), String.t()) ::
+          {:ok, [non_neg_integer()], float()} | :no_match
+  def match_string(haystack, query) do
+    q = query |> String.downcase() |> String.graphemes()
+    subsequence_match(String.downcase(haystack), q)
   end
 
   # --- Server ---
@@ -128,7 +145,9 @@ defmodule ClaudePlans.DirIndex do
     case File.ls(current) do
       {:ok, entries} ->
         entries
-        |> Enum.filter(fn name -> not String.starts_with?(name, ".") end)
+        |> Enum.filter(fn name ->
+          not String.starts_with?(name, ".") and name not in @skip_dirs
+        end)
         |> Enum.sort()
         |> Enum.reduce(acc, fn name, acc ->
           if Process.get(ref) >= max do
@@ -164,7 +183,8 @@ defmodule ClaudePlans.DirIndex do
         sub =
           entries
           |> Enum.filter(fn name ->
-            not String.starts_with?(name, ".") and File.dir?(Path.join(path, name))
+            not String.starts_with?(name, ".") and name not in @skip_dirs and
+              File.dir?(Path.join(path, name))
           end)
           |> Enum.take(50)
           |> Enum.reduce(0, fn dir, acc ->
@@ -188,7 +208,8 @@ defmodule ClaudePlans.DirIndex do
         sub =
           entries
           |> Enum.filter(fn name ->
-            not String.starts_with?(name, ".") and File.dir?(Path.join(path, name))
+            not String.starts_with?(name, ".") and name not in @skip_dirs and
+              File.dir?(Path.join(path, name))
           end)
           |> Enum.take(30)
           |> Enum.reduce(0, fn dir, acc ->

--- a/lib/claude_plans/web/browser_live.ex
+++ b/lib/claude_plans/web/browser_live.ex
@@ -759,9 +759,11 @@ defmodule ClaudePlans.Web.BrowserLive do
       base = socket.assigns.browse_path
       {:noreply, assign(socket, browse_dirs: list_subdirs(base), browse_filter: "")}
     else
-      # Instant search from pre-built index — returns [{path, match_indices}]
-      results = ClaudePlans.DirIndex.search(query, 30)
-      {:noreply, assign(socket, browse_dirs: results, browse_filter: query)}
+      base = socket.assigns.browse_path
+      local = local_filter_matches(base, query)
+      index_results = ClaudePlans.DirIndex.search(query, 30)
+      merged = merge_browse_results(local, index_results, base)
+      {:noreply, assign(socket, browse_dirs: merged, browse_filter: query)}
     end
   end
 
@@ -1816,6 +1818,50 @@ defmodule ClaudePlans.Web.BrowserLive do
       {:error, _} ->
         []
     end
+  end
+
+  # Fuzzy-match immediate children of `base` against `query` using the same
+  # scoring as DirIndex. Guarantees the folder under the user's cursor is
+  # always selectable, even if the background indexer hasn't reached it.
+  defp local_filter_matches(base, query) do
+    case File.ls(base) do
+      {:ok, entries} ->
+        entries
+        |> Enum.filter(fn name ->
+          not String.starts_with?(name, ".") and File.dir?(Path.join(base, name))
+        end)
+        |> Enum.flat_map(fn name ->
+          case ClaudePlans.DirIndex.match_string(name, query) do
+            {:ok, indices, score} -> [{name, indices, score}]
+            :no_match -> []
+          end
+        end)
+        |> Enum.sort_by(fn {_n, _i, s} -> s end, :desc)
+        |> Enum.take(30)
+        |> Enum.map(fn {n, i, _s} -> {n, i} end)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  # Concatenate local results first (they represent the user's current browse
+  # context), then index results, dropping any index entry whose absolute path
+  # is already represented locally.
+  defp merge_browse_results(local, index_results, base) do
+    home = System.user_home!()
+
+    local_abs =
+      local
+      |> Enum.map(fn {name, _indices} -> Path.expand(Path.join(base, name)) end)
+      |> MapSet.new()
+
+    deduped =
+      Enum.reject(index_results, fn {rel, _idx, _direct, _sub} ->
+        MapSet.member?(local_abs, Path.expand(Path.join(home, rel)))
+      end)
+
+    local ++ deduped
   end
 
   # Reusable annotation panel for LiveComponent-based tabs (Folders, Projects)


### PR DESCRIPTION
## Summary
The DirIndex background scan can take seconds before reaching deep paths. During that window, the folder under the user's cursor isn't selectable from the browse search. Two coordinated changes fix that:

**`DirIndex`**
- New `@skip_dirs` filter — skip `deps`, `node_modules`, `_build`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `Pods`, `vendor`, `.next`, `.nuxt`, `.turbo`. These rarely contain user work and would exhaust `@max_entries` (10k) before reaching real projects.
- New public `match_string/2` helper — exposes the existing subsequence scoring against an arbitrary haystack so callers can score paths that aren't in the index.

**`BrowserLive`**
- On every search, fuzzy-match immediate children of the current `browse_path` locally (`local_filter_matches/2`) and merge them ahead of `DirIndex.search/2` results, deduping by absolute path (`merge_browse_results/3`).
- Local results render as 2-tuples `{name, indices}` — the existing template helpers in `sidebar_components.ex` already handle this shape (lines 373, 384, 388), so no template changes needed.

## Test plan
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix format --check-formatted\` clean
- [x] \`mix test\` — 79 tests, 0 failures
- [ ] Smoke-test in browser: open browse search, navigate into a deep folder before the indexer finishes, type the name of an immediate child — confirm it appears at the top of results
- [ ] Confirm \`node_modules\` / \`_build\` no longer appear in browse search results from a fresh index

🤖 Generated with [Claude Code](https://claude.com/claude-code)