### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-05-10
+
+### Added
+- **Browse search always finds the folder under your cursor** — When typing in the "Add folder" browse search, the immediate children of the directory you're currently browsing are fuzzy-matched locally and shown ahead of background-index results. You no longer need to wait for the background indexer to reach a deep directory before its children become selectable
+
+### Changed
+- **Background directory indexer skips heavy build/cache dirs** — `deps`, `node_modules`, `_build`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `Pods`, `vendor`, `.next`, `.nuxt`, `.turbo` are no longer descended into. The 10k-entry budget is spent on real project directories instead, so deeper user folders show up in browse search faster and irrelevant build output no longer pollutes results
+- **Activity feed reads are lock-free** — `ActivityFeed.list_events/0` now reads directly from a protected ETS table instead of going through `GenServer.call`. Eliminates LiveView mount timeouts when the feed process is briefly busy with file-system I/O
+
+### Fixed
+- **Annotation panel stale on file switch** — Selecting a different file in the Projects or Folders viewer now clears the annotation panel for the previous file, instead of leaving the prior file's annotations visible
+
 ## [0.10.2] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ claude-plans
 
 ```bash
 # macOS Apple Silicon
-curl -L -o claude-plans https://github.com/jhlee111/claude_plans/releases/download/v0.10.2/claude_plans_macos_arm
+curl -L -o claude-plans https://github.com/jhlee111/claude_plans/releases/download/v0.11.0/claude_plans_macos_arm
 chmod +x claude-plans
 ./claude-plans
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ClaudePlans.MixProject do
   use Mix.Project
 
-  @version "0.10.2"
+  @version "0.11.0"
 
   def project do
     [


### PR DESCRIPTION
## Summary
- Bump version to 0.11.0
- Update CHANGELOG.md
- Update README direct-download URL to v0.11.0

### What's new in v0.11.0

**Added**
- Browse search now always finds the folder under your cursor — immediate children of the current browse path are fuzzy-matched locally and shown ahead of background-index results, so you don't have to wait for the indexer to reach deep paths.

**Changed**
- Background directory indexer skips heavy build/cache dirs (`deps`, `node_modules`, `_build`, `target`, `dist`, `build`, `.venv`, `venv`, `__pycache__`, `Pods`, `vendor`, `.next`, `.nuxt`, `.turbo`). The 10k-entry budget is spent on real project directories, so deeper user folders surface faster and irrelevant build output no longer pollutes results.
- `ActivityFeed.list_events/0` now reads directly from a protected ETS table instead of going through `GenServer.call`. Eliminates LiveView mount timeouts when the feed process is briefly busy.

**Fixed**
- Annotation panel stale on file switch in Projects/Folders viewers — selecting a different file now clears the prior file's annotations.

## Post-merge
\`\`\`
git checkout main && git pull
git tag v0.11.0
git push --tags
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)